### PR TITLE
Fix typo in bio

### DIFF
--- a/_includes/people.html
+++ b/_includes/people.html
@@ -13,7 +13,7 @@
         <h2>Talks</h2>
         <p>Invited Speakers</p>
       </div>
-      
+
       <div class="columns is-multiline">
         <div class="column is-one-third">
           <figure class="image is-square">
@@ -30,7 +30,7 @@
           </figure>
         </div>
         <div class="column is-half">
-            <p><a href="https://janphilippfranken.github.io/">Jan-Philipp Fränken</a> is a post-doctoral research at Stanford University. He is interested in representation learning, causal inference, and theory of mind reasoning. He currently works on MARPLE: Explaining what happened through multimodal simulation.</p>
+            <p><a href="https://janphilippfranken.github.io/">Jan-Philipp Fränken</a> is a post-doctoral researcher at Stanford University. He is interested in representation learning, causal inference, and theory of mind reasoning. He currently works on MARPLE: Explaining what happened through multimodal simulation.</p>
         </div>
 
         <div class="column is-one-third">
@@ -229,12 +229,12 @@
     <!-- ======= PC Section ======= -->
     <section id="pc" class="section">
         <div class="container">
-  
+
           <div class="section-title" data-aos="zoom-out">
             <!-- <h2>Organization</h2> -->
             <p>Program Committee</p>
           </div>
-  
+
           <div class="row">
               <!-- Maarten Sap (AI2), Jack Hessel (AI2), Keisuke Sakaguchi (AI2), Prithviraj Ammanabrolu (AI2), Tuhin Chakrabarty (Columbia), Liwei Jiang (UW), Alisa Liu (UW), Rowan Zellers (UW), Lianhui Qin (UW), Ximing Lu (UW), Michi Yasunaga (Stanford), Xikun Zhang (Stanford), Deniz Bayazit (EPFL), Silin Gao (EPFL), Aman Madaan (CMU), Khyathi Chandu (CMU), Yanai Elazar (Bar-Ilan), Avijit Thawani (USC), Pei Zhou (USC), Yu Hou (USC), Anurag Acharya (Florida International), Sarah Wiegreffe  (Georgia Tech), Abhilasha Sancheti (UMD), Neha Srikanth (UMD), Sheng Zhang (Microsoft), Yue Dong (McGill), Denis Emelin (Edinburgh), Simon Razniewski (MPI), Filip ilievski (USC ISI), Mayank Kejriwal (USC ISI), Jeff Da (AI2), Sumit Bhatia (Adobe Research), Manuel Ciosici (USC ISI), Chandra Bhagavatula (AI2), Ronan Le Bras (AI2), Emily Allaway (Columbia), Hongyu Ren (Stanford), Max Forbes (UW), Neha Srikanth (UMD), John Hewitt (Stanford), Shikhar Murty (Stanford), Eric Mitchell (Stanford), Shaobo Cui (EPFL), Lisa Bauer (UNC), Faeze Brahman (UCSC)  -->
 
@@ -261,7 +261,7 @@
                   <li>Ini Oguntola (Carnegie Mellon University)</li>
                   <li>Herbie Bradley (University of Cambridge)</li>
                   <li>Kai Zhang (Ohio State University, Columbus)</li>
-  
+
                 </ul>
                 </div>
                 <div style="float: right; width: 50%;">
@@ -288,8 +288,8 @@
                   <li>Soham Dinesh Tiwari (Carnegie Mellon University)</li>
                 </ul>
                 </div>
-        
-          </div>  
+
+          </div>
         </div>
       </section><!-- End PC Section -->
 


### PR DESCRIPTION
I needed to fix a typo before I ask Kevin if he has a 3rd-person bio that he'd like to use. The current one collected from the lab page looks a bit too short 😅